### PR TITLE
Fix macros cross parse

### DIFF
--- a/src/cs/production/CAstFfi.Tool/Extract/Domain/Explore/Explorer.cs
+++ b/src/cs/production/CAstFfi.Tool/Extract/Domain/Explore/Explorer.cs
@@ -70,6 +70,8 @@ public sealed partial class Explorer
             TryEnqueueVisitInfoNode,
             linkedPaths);
 
+        var platformScope = _logger.BeginScope(targetPlatform)!;
+
         try
         {
             VisitTranslationUnit(context, translationUnit, headerFilePath);
@@ -87,6 +89,8 @@ public sealed partial class Explorer
 
         CleanUp(context);
         LogSuccess();
+
+        platformScope.Dispose();
         return result;
     }
 

--- a/src/cs/production/CAstFfi.Tool/Extract/Domain/Explore/Explorer.cs
+++ b/src/cs/production/CAstFfi.Tool/Extract/Domain/Explore/Explorer.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using System.Text;
+using CAstFfi.Common;
 using CAstFfi.Data;
 using CAstFfi.Extract.Domain.Explore.Handlers;
 using CAstFfi.Extract.Domain.Parse;
@@ -207,7 +208,7 @@ public sealed partial class Explorer
         LogExploringMacros();
         var macroObjectCandidates = _macroObjectCandidates.ToImmutableArray();
         var macroObjects = _parser.MacroObjects(
-            macroObjectCandidates, context.TargetPlatformRequested, context.ParseOptions);
+            macroObjectCandidates, NativeUtility.HostPlatform, context.ParseOptions);
         var macroNamesFound = macroObjects.Select(macroObject => macroObject.Name).ToArray();
         var macroNamesFoundString = string.Join(", ", macroNamesFound);
         LogFoundMacros(macroNamesFound.Length, macroNamesFoundString);

--- a/src/cs/production/CAstFfi.Tool/Extract/Domain/Parse/ClangArgumentsBuilder.cs
+++ b/src/cs/production/CAstFfi.Tool/Extract/Domain/Parse/ClangArgumentsBuilder.cs
@@ -233,7 +233,9 @@ public sealed partial class ClangArgumentsBuilder
         }
 
         directories.AddRange(manualSystemIncludeDirectories);
-        return directories.ToImmutable();
+
+        var result = directories.Distinct().ToImmutableArray();
+        return result;
     }
 
     private void SystemIncludeDirectoriesHostWindows(

--- a/src/cs/production/CAstFfi.Tool/Properties/appsettings.json
+++ b/src/cs/production/CAstFfi.Tool/Properties/appsettings.json
@@ -3,7 +3,7 @@
     "Console": {
       "LogLevel": {
         "Default": "Warning",
-        "CAST": "Information"
+        "CAstFfi": "Debug"
       },
       "FormatterOptions": {
         "ColorBehavior": "Enabled",


### PR DESCRIPTION
Fix cross-parsing: use the native platform architecture when parsing macro candidates C++ file.

Other small quality of life things:
   - Add platform logger scope per AST extract
   - Distinct system include directories