### PR TITLE
Add 64 bit enum tests

### DIFF
--- a/src/c/tests/_container_library/main.c
+++ b/src/c/tests/_container_library/main.c
@@ -5,3 +5,4 @@
 #include "../function_pointers/_index.h"
 #include "../opaque_types/_index.h"
 #include "../macro_objects/_index.h"
+#include "../ignored/_index.h"

--- a/src/c/tests/enums/Enum_Force_SInt32.h
+++ b/src/c/tests/enums/Enum_Force_SInt32.h
@@ -7,7 +7,7 @@ typedef enum Enum_Force_SInt32 {
     ENUM_FORCE_SINT32_DAY_WEDNESDAY,
     ENUM_FORCE_SINT32_DAY_THURSDAY,
     ENUM_FORCE_SINT32_DAY_FRIDAY,
-    _ENUM_FORCE_SINT32 = 0x7FFFFFFF
+    _ENUM_FORCE_SINT32 = 0x7FFFFFFFL
 } Enum_Force_SInt32;
 
 FFI_API_DECL void Enum_Force_SInt32__print_Enum_Force_SInt32(const Enum_Force_SInt32 e)

--- a/src/c/tests/enums/Enum_Force_SInt64.h
+++ b/src/c/tests/enums/Enum_Force_SInt64.h
@@ -1,0 +1,21 @@
+#pragma once
+
+typedef enum Enum_Force_SInt64 {
+    ENUM_FORCE_SINT64_DAY_UNKNOWN,
+    ENUM_FORCE_SINT64_DAY_MONDAY,
+    ENUM_FORCE_SINT64_DAY_TUESDAY,
+    ENUM_FORCE_SINT64_DAY_WEDNESDAY,
+    ENUM_FORCE_SINT64_DAY_THURSDAY,
+    ENUM_FORCE_SINT64_DAY_FRIDAY,
+    _ENUM_FORCE_SINT64 = 0x7FFFFFFFFFFFFFFFLL
+} Enum_Force_SInt64;
+
+FFI_API_DECL void Enum_Force_SInt64__print_Enum_Force_SInt64(const Enum_Force_SInt64 e)
+{
+    printf("%d\n", e); // Print used for testing
+}
+
+FFI_API_DECL Enum_Force_SInt64 Enum_Force_SInt64__return_Enum_Force_SInt64(const Enum_Force_SInt64 e)
+{
+    return e;
+}

--- a/src/c/tests/enums/Enum_Force_UInt32.h
+++ b/src/c/tests/enums/Enum_Force_UInt32.h
@@ -7,7 +7,7 @@ typedef enum Enum_Force_UInt32 {
     ENUM_FORCE_UINT32_DAY_WEDNESDAY,
     ENUM_FORCE_UINT32_DAY_THURSDAY,
     ENUM_FORCE_UINT32_DAY_FRIDAY,
-    _ENUM_FORCE_UINT32 = 0xFFFFFFFF
+    _ENUM_FORCE_UINT32 = 0xFFFFFFFFUL
 } Enum_Force_UInt32;
 
 FFI_API_DECL void Enum_Force_UInt32__print_Enum_Force_UInt32(const Enum_Force_UInt32 e)

--- a/src/c/tests/enums/Enum_Force_UInt64.h
+++ b/src/c/tests/enums/Enum_Force_UInt64.h
@@ -1,0 +1,21 @@
+#pragma once
+
+typedef enum Enum_Force_UInt64 {
+    ENUM_FORCE_UINT64_DAY_UNKNOWN,
+    ENUM_FORCE_UINT64_DAY_MONDAY,
+    ENUM_FORCE_UINT64_DAY_TUESDAY,
+    ENUM_FORCE_UINT64_DAY_WEDNESDAY,
+    ENUM_FORCE_UINT64_DAY_THURSDAY,
+    ENUM_FORCE_UINT64_DAY_FRIDAY,
+    _ENUM_FORCE_UINT64 = 0xFFFFFFFFFFFFFFFFULL
+} Enum_Force_UInt64;
+
+FFI_API_DECL void Enum_Force_UInt64__print_Enum_Force_UInt64(const Enum_Force_UInt64 e)
+{
+    printf("%d\n", e); // Print used for testing
+}
+
+FFI_API_DECL Enum_Force_UInt64 Enum_Force_UInt64__return_Enum_Force_UInt64(const Enum_Force_UInt64 e)
+{
+    return e;
+}

--- a/src/c/tests/enums/_index.h
+++ b/src/c/tests/enums/_index.h
@@ -3,7 +3,8 @@
 #include "Enum_Force_SInt8.h"
 #include "Enum_Force_SInt16.h"
 #include "Enum_Force_SInt32.h"
-
+#include "Enum_Force_SInt64.h"
 #include "Enum_Force_UInt8.h"
 #include "Enum_Force_UInt16.h"
 #include "Enum_Force_UInt32.h"
+#include "Enum_Force_UInt64.h"

--- a/src/c/tests/ignored/EnumIgnored.h
+++ b/src/c/tests/ignored/EnumIgnored.h
@@ -1,0 +1,21 @@
+#pragma once
+
+typedef enum EnumIgnored {
+    ENUM_IGNORED_DAY_UNKNOWN,
+    ENUM_IGNORED_DAY_MONDAY,
+    ENUM_IGNORED_DAY_TUESDAY,
+    ENUM_IGNORED_DAY_WEDNESDAY,
+    ENUM_IGNORED_DAY_THURSDAY,
+    ENUM_IGNORED_DAY_FRIDAY,
+    _ENUM_IGNORED_SINT8 = 0x7F
+} EnumIgnored;
+
+FFI_API_DECL void EnumIgnored__print_EnumIgnored(const EnumIgnored e)
+{
+    printf("%d\n", e); // Print used for testing
+}
+
+FFI_API_DECL EnumIgnored EnumIgnored__return_EnumIgnored(const EnumIgnored e)
+{
+    return e;
+}

--- a/src/c/tests/ignored/MacroObjectIgnored.h
+++ b/src/c/tests/ignored/MacroObjectIgnored.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#define MACRO_OBJECT_IGNORED 42
+
+FFI_API_DECL int MacroObjectIgnored__return_int()
+{
+    return MACRO_OBJECT_IGNORED;
+}

--- a/src/c/tests/ignored/_index.h
+++ b/src/c/tests/ignored/_index.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "EnumIgnored.h"
+#include "MacroObjectIgnored.h"

--- a/src/cs/production/CAstFfi.Tool/Features/Extract/Domain/Explore/ExploreContext.cs
+++ b/src/cs/production/CAstFfi.Tool/Features/Extract/Domain/Explore/ExploreContext.cs
@@ -250,8 +250,7 @@ public sealed class ExploreContext
             typeCursor.GetDescendents(
                 static (
                     cursor,
-                    _) => cursor.kind == CXCursorKind.CXCursor_EnumConstantDecl,
-                false);
+                    _) => cursor.kind == CXCursorKind.CXCursor_EnumConstantDecl);
         /* Example C code; this enum should have it's single member promoted as a macro object.
 enum {
 noErr = 0

--- a/src/cs/production/CAstFfi.Tool/Features/Extract/Domain/Explore/Handlers/EnumExplorer.cs
+++ b/src/cs/production/CAstFfi.Tool/Features/Extract/Domain/Explore/Handlers/EnumExplorer.cs
@@ -62,8 +62,7 @@ public sealed class EnumExplorer : ExploreNodeHandler<CEnum>
         var builder = ImmutableArray.CreateBuilder<CEnumValue>();
 
         var enumValuesCursors = cursor.GetDescendents(
-            (child, _) => child.kind == CXCursorKind.CXCursor_EnumConstantDecl,
-            false);
+            static (child, _) => child.kind == CXCursorKind.CXCursor_EnumConstantDecl);
 
         foreach (var enumValueCursor in enumValuesCursors)
         {

--- a/src/cs/production/CAstFfi.Tool/Features/Extract/Domain/Parse/Parser.cs
+++ b/src/cs/production/CAstFfi.Tool/Features/Extract/Domain/Parse/Parser.cs
@@ -521,12 +521,8 @@ int main(void)
         ExtractParseOptions options)
     {
         var translationUnitCursor = clang_getTranslationUnitCursor(translationUnit);
-
-        var isEnabledSingleHeader = options.IsEnabledSingleHeader;
         var cursors = translationUnitCursor.GetDescendents(
-            (child, _) => IsMacroOfInterest(child, options),
-            !isEnabledSingleHeader);
-
+            (child, _) => IsMacroOfInterest(child, options));
         return cursors;
     }
 
@@ -560,6 +556,18 @@ int main(void)
         if (isMacroFunction)
         {
             return false;
+        }
+
+        var location = cursor.GetLocation();
+        if (location != null)
+        {
+            foreach (var ignoredIncludeDirectory in options.IgnoredIncludeDirectories)
+            {
+                if (location.Value.FullFilePath.Contains(ignoredIncludeDirectory, StringComparison.InvariantCulture))
+                {
+                    return false;
+                }
+            }
         }
 
         var name = cursor.Name();

--- a/src/cs/production/CAstFfi.Tool/Features/Extract/Input/Sanitized/ExtractExploreOptions.cs
+++ b/src/cs/production/CAstFfi.Tool/Features/Extract/Input/Sanitized/ExtractExploreOptions.cs
@@ -11,5 +11,7 @@ public sealed class ExtractExploreOptions
 
     public bool IsEnabledOnlyExternalTopLevelCursors { get; init; }
 
+    public ImmutableHashSet<string> IgnoredIncludeDirectories { get; init; } = ImmutableHashSet<string>.Empty;
+
     public ImmutableHashSet<string> OpaqueTypeNames { get; init; } = ImmutableHashSet<string>.Empty;
 }

--- a/src/cs/production/CAstFfi.Tool/Features/Extract/Input/Sanitized/ExtractParseOptions.cs
+++ b/src/cs/production/CAstFfi.Tool/Features/Extract/Input/Sanitized/ExtractParseOptions.cs
@@ -11,6 +11,8 @@ public sealed class ExtractParseOptions
 
     public ImmutableArray<string> SystemIncludeDirectories { get; init; } = ImmutableArray<string>.Empty;
 
+    public ImmutableHashSet<string> IgnoredIncludeDirectories { get; init; } = ImmutableHashSet<string>.Empty;
+
     public ImmutableArray<string> MacroObjectDefines { get; init; } = ImmutableArray<string>.Empty;
 
     public ImmutableArray<string> AdditionalArguments { get; init; } = ImmutableArray<string>.Empty;
@@ -20,6 +22,4 @@ public sealed class ExtractParseOptions
     public ImmutableArray<string> AppleFrameworks { get; init; }
 
     public bool IsEnabledSystemDeclarations { get; init; }
-
-    public bool IsEnabledSingleHeader { get; init; }
 }

--- a/src/cs/production/CAstFfi.Tool/Features/Extract/Input/Unsanitized/UnsanitizedExtractOptions.cs
+++ b/src/cs/production/CAstFfi.Tool/Features/Extract/Input/Unsanitized/UnsanitizedExtractOptions.cs
@@ -42,6 +42,12 @@ public sealed class UnsanitizedExtractOptions
     public ImmutableArray<string>? SystemIncludeDirectories { get; set; }
 
     /// <summary>
+    ///     The directories to ignore header files for either user or system.
+    /// </summary>
+    [JsonPropertyName("ignoredIncludeDirectories")]
+    public ImmutableArray<string>? IgnoredIncludeDirectories { get; set; }
+
+    /// <summary>
     ///     Determines whether to show the the path of header code locations with full paths or relative paths.
     /// </summary>
     /// <remarks>
@@ -89,20 +95,6 @@ public sealed class UnsanitizedExtractOptions
     /// </remarks>
     [JsonPropertyName("isEnabledAutomaticallyFindSystemHeaders")]
     public bool? IsEnabledAutomaticallyFindSystemHeaders { get; set; }
-
-    /// <summary>
-    ///     Determines whether to parse the main input header file and all transitive inclusive header files as if it
-    ///     were a single translation unit.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///         Default is <c>true</c>. Use <c>true</c> to parse the the main input header file and all transitive
-    ///         inclusive headers as if it were a single translation unit. Use <c>false</c> to parse each translation
-    ///         unit independently.
-    ///     </para>
-    /// </remarks>
-    [JsonPropertyName("isEnabledParseAsSingleHeader")]
-    public bool? IsEnabledParseAsSingleHeader { get; set; }
 
     /// <summary>
     ///     Determines whether to parse only the top-level cursors which are externally visible, or all top-level cursors.

--- a/src/cs/production/CAstFfi.Tool/Features/Extract/Input/Unsanitized/UnsanitizedExtractOptionsTargetPlatform.cs
+++ b/src/cs/production/CAstFfi.Tool/Features/Extract/Input/Unsanitized/UnsanitizedExtractOptionsTargetPlatform.cs
@@ -24,6 +24,12 @@ public sealed class UnsanitizedExtractOptionsTargetPlatform
     public ImmutableArray<string>? SystemIncludeDirectories { get; set; }
 
     /// <summary>
+    ///     The directories to ignore header files for either user or system.
+    /// </summary>
+    [JsonPropertyName("ignoredIncludeDirectories")]
+    public ImmutableArray<string>? IgnoredIncludeDirectories { get; set; }
+
+    /// <summary>
     ///     The object-like macros to use when parsing C code.
     /// </summary>
     [JsonPropertyName("defines")]

--- a/src/cs/tests/CAstFfi.Tests/Data/Values/aarch64-apple-darwin/Enums/Enum_Force_SInt64.json
+++ b/src/cs/tests/CAstFfi.Tests/Data/Values/aarch64-apple-darwin/Enums/Enum_Force_SInt64.json
@@ -1,0 +1,34 @@
+{
+  "name": "Enum_Force_SInt64",
+  "type_integer": "unsigned long",
+  "values": [
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_UNKNOWN",
+      "value": 0
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_MONDAY",
+      "value": 1
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_TUESDAY",
+      "value": 2
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_WEDNESDAY",
+      "value": 3
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_THURSDAY",
+      "value": 4
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_FRIDAY",
+      "value": 5
+    },
+    {
+      "name": "_ENUM_FORCE_SINT64",
+      "value": 9223372036854775807
+    }
+  ]
+}

--- a/src/cs/tests/CAstFfi.Tests/Data/Values/aarch64-apple-darwin/Enums/Enum_Force_UInt64.json
+++ b/src/cs/tests/CAstFfi.Tests/Data/Values/aarch64-apple-darwin/Enums/Enum_Force_UInt64.json
@@ -1,0 +1,34 @@
+{
+  "name": "Enum_Force_UInt64",
+  "type_integer": "unsigned long",
+  "values": [
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_UNKNOWN",
+      "value": 0
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_MONDAY",
+      "value": 1
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_TUESDAY",
+      "value": 2
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_WEDNESDAY",
+      "value": 3
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_THURSDAY",
+      "value": 4
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_FRIDAY",
+      "value": 5
+    },
+    {
+      "name": "_ENUM_FORCE_UINT64",
+      "value": -1
+    }
+  ]
+}

--- a/src/cs/tests/CAstFfi.Tests/Data/Values/aarch64-apple-ios/Enums/Enum_Force_SInt64.json
+++ b/src/cs/tests/CAstFfi.Tests/Data/Values/aarch64-apple-ios/Enums/Enum_Force_SInt64.json
@@ -1,0 +1,34 @@
+{
+  "name": "Enum_Force_SInt64",
+  "type_integer": "unsigned long",
+  "values": [
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_UNKNOWN",
+      "value": 0
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_MONDAY",
+      "value": 1
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_TUESDAY",
+      "value": 2
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_WEDNESDAY",
+      "value": 3
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_THURSDAY",
+      "value": 4
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_FRIDAY",
+      "value": 5
+    },
+    {
+      "name": "_ENUM_FORCE_SINT64",
+      "value": 9223372036854775807
+    }
+  ]
+}

--- a/src/cs/tests/CAstFfi.Tests/Data/Values/aarch64-apple-ios/Enums/Enum_Force_UInt64.json
+++ b/src/cs/tests/CAstFfi.Tests/Data/Values/aarch64-apple-ios/Enums/Enum_Force_UInt64.json
@@ -1,0 +1,34 @@
+{
+  "name": "Enum_Force_UInt64",
+  "type_integer": "unsigned long",
+  "values": [
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_UNKNOWN",
+      "value": 0
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_MONDAY",
+      "value": 1
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_TUESDAY",
+      "value": 2
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_WEDNESDAY",
+      "value": 3
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_THURSDAY",
+      "value": 4
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_FRIDAY",
+      "value": 5
+    },
+    {
+      "name": "_ENUM_FORCE_UINT64",
+      "value": -1
+    }
+  ]
+}

--- a/src/cs/tests/CAstFfi.Tests/Data/Values/i686-apple-darwin/Enums/Enum_Force_SInt64.json
+++ b/src/cs/tests/CAstFfi.Tests/Data/Values/i686-apple-darwin/Enums/Enum_Force_SInt64.json
@@ -1,0 +1,34 @@
+{
+  "name": "Enum_Force_SInt64",
+  "type_integer": "unsigned long long",
+  "values": [
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_UNKNOWN",
+      "value": 0
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_MONDAY",
+      "value": 1
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_TUESDAY",
+      "value": 2
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_WEDNESDAY",
+      "value": 3
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_THURSDAY",
+      "value": 4
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_FRIDAY",
+      "value": 5
+    },
+    {
+      "name": "_ENUM_FORCE_SINT64",
+      "value": 9223372036854775807
+    }
+  ]
+}

--- a/src/cs/tests/CAstFfi.Tests/Data/Values/i686-apple-darwin/Enums/Enum_Force_UInt64.json
+++ b/src/cs/tests/CAstFfi.Tests/Data/Values/i686-apple-darwin/Enums/Enum_Force_UInt64.json
@@ -1,0 +1,34 @@
+{
+  "name": "Enum_Force_UInt64",
+  "type_integer": "unsigned long long",
+  "values": [
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_UNKNOWN",
+      "value": 0
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_MONDAY",
+      "value": 1
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_TUESDAY",
+      "value": 2
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_WEDNESDAY",
+      "value": 3
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_THURSDAY",
+      "value": 4
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_FRIDAY",
+      "value": 5
+    },
+    {
+      "name": "_ENUM_FORCE_UINT64",
+      "value": -1
+    }
+  ]
+}

--- a/src/cs/tests/CAstFfi.Tests/Data/Values/x86_64-apple-darwin/Enums/Enum_Force_SInt64.json
+++ b/src/cs/tests/CAstFfi.Tests/Data/Values/x86_64-apple-darwin/Enums/Enum_Force_SInt64.json
@@ -1,0 +1,34 @@
+{
+  "name": "Enum_Force_SInt64",
+  "type_integer": "unsigned long",
+  "values": [
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_UNKNOWN",
+      "value": 0
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_MONDAY",
+      "value": 1
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_TUESDAY",
+      "value": 2
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_WEDNESDAY",
+      "value": 3
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_THURSDAY",
+      "value": 4
+    },
+    {
+      "name": "ENUM_FORCE_SINT64_DAY_FRIDAY",
+      "value": 5
+    },
+    {
+      "name": "_ENUM_FORCE_SINT64",
+      "value": 9223372036854775807
+    }
+  ]
+}

--- a/src/cs/tests/CAstFfi.Tests/Data/Values/x86_64-apple-darwin/Enums/Enum_Force_UInt64.json
+++ b/src/cs/tests/CAstFfi.Tests/Data/Values/x86_64-apple-darwin/Enums/Enum_Force_UInt64.json
@@ -1,0 +1,34 @@
+{
+  "name": "Enum_Force_UInt64",
+  "type_integer": "unsigned long",
+  "values": [
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_UNKNOWN",
+      "value": 0
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_MONDAY",
+      "value": 1
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_TUESDAY",
+      "value": 2
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_WEDNESDAY",
+      "value": 3
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_THURSDAY",
+      "value": 4
+    },
+    {
+      "name": "ENUM_FORCE_UINT64_DAY_FRIDAY",
+      "value": 5
+    },
+    {
+      "name": "_ENUM_FORCE_UINT64",
+      "value": -1
+    }
+  ]
+}

--- a/src/cs/tests/CAstFfi.Tests/TestCCode.cs
+++ b/src/cs/tests/CAstFfi.Tests/TestCCode.cs
@@ -22,11 +22,9 @@ public class TestCCode : TestBase
         "Enum_Force_SInt8",
         "Enum_Force_SInt16",
         "Enum_Force_SInt32",
-        "Enum_Force_SInt64",
         "Enum_Force_UInt8",
         "Enum_Force_UInt16",
-        "Enum_Force_UInt32",
-        "Enum_Force_UInt64"
+        "Enum_Force_UInt32"
     };
 
     [Theory]
@@ -37,6 +35,22 @@ public class TestCCode : TestBase
         {
             var value = ast.GetEnum(name);
             AssertValue(name, value, $"{ast.TargetPlatformRequested}/Enums");
+        }
+    }
+
+    public static TheoryData<string> EnumNamesIgnored => new()
+    {
+        "EnumIgnored"
+    };
+
+    [Theory]
+    [MemberData(nameof(EnumNamesIgnored))]
+    public void EnumIgnored(string name)
+    {
+        foreach (var ast in _fixture.AbstractSyntaxTrees)
+        {
+            var value = ast.TryGetEnum(name);
+            Assert.True(value == null, $"The enum '{name}' was not ignored.");
         }
     }
 
@@ -92,6 +106,22 @@ public class TestCCode : TestBase
         {
             var value = ast.GetMacroObject(name);
             AssertValue(name, value, $"{ast.TargetPlatformRequested}/MacroObjects");
+        }
+    }
+
+    public static TheoryData<string> MacroObjectNamesIgnored() => new()
+    {
+        "MACRO_OBJECT_IGNORED"
+    };
+
+    [Theory]
+    [MemberData(nameof(MacroObjectNamesIgnored))]
+    public void MacroObjectIgnored(string name)
+    {
+        foreach (var ast in _fixture.AbstractSyntaxTrees)
+        {
+            var value = ast.TryGetMacroObject(name);
+            Assert.True(value == null, $"The macro object '{name}' was not ignored.");
         }
     }
 

--- a/src/cs/tests/CAstFfi.Tests/TestCCode.cs
+++ b/src/cs/tests/CAstFfi.Tests/TestCCode.cs
@@ -22,10 +22,11 @@ public class TestCCode : TestBase
         "Enum_Force_SInt8",
         "Enum_Force_SInt16",
         "Enum_Force_SInt32",
-
+        "Enum_Force_SInt64",
         "Enum_Force_UInt8",
         "Enum_Force_UInt16",
-        "Enum_Force_UInt32"
+        "Enum_Force_UInt32",
+        "Enum_Force_UInt64"
     };
 
     [Theory]
@@ -97,7 +98,7 @@ public class TestCCode : TestBase
     private readonly TestFixtureCCode _fixture;
 
     public TestCCode()
-        : base("Data/Values", false)
+        : base("Data/Values", true)
     {
         var services = TestHost.Services;
         _fixture = services.GetService<TestFixtureCCode>()!;

--- a/src/cs/tests/CAstFfi.Tests/config.json
+++ b/src/cs/tests/CAstFfi.Tests/config.json
@@ -3,6 +3,9 @@
     "userIncludeDirectories": [
         "../../../../src/c/production/ffi_helper/include"
     ],
+    "ignoredIncludeDirectories": [
+      "../../../../src/c/tests/ignored"
+    ],
     "opaqueTypeNames": [
         "OpaqueType_PlatformSpecificSize"
     ],


### PR DESCRIPTION
Note that on MSVC, trying to force the value to be a 64 bits is not effective. MSVC will say it's still a 4 byte integer backed enum. These tests reflect that.